### PR TITLE
Remember start of day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## Pending
 
+- Remember start and end of day.
+
 ## [0.5.1] - 2023-10-15
-- Improve first login with default project and activity
+- Improve first login with default project and activity.
 - Add header for current activity when viewing timesheet on small screens.
-- 
+
 ## [0.5.0] - 2023-10-15
 - Enable open user registration.
 

--- a/src/Quarter.Core/Models/User.cs
+++ b/src/Quarter.Core/Models/User.cs
@@ -13,7 +13,7 @@ public enum UserRole
 
 public class User : IAggregate<User>
 {
-    public static readonly List<UserRole> NoRoles = new();
+    public static readonly List<UserRole> NoRoles = [];
 
     [JsonConverter(typeof(IdOfJsonConverter<User>))]
     public IdOf<User> Id { get; set; }

--- a/src/Quarter/Pages/Application/Timesheet/TimesheetGrid.razor
+++ b/src/Quarter/Pages/Application/Timesheet/TimesheetGrid.razor
@@ -64,8 +64,8 @@
     // automated.
 
     // The timesheet limits the day view with actions to extend that perspective
-    private DayLimit _dayStart = new DayLimit(ApplicationState.DefaultStartHour, 0, true);
-    private DayLimit _dayEnd = new DayLimit(ApplicationState.DefaultEndHour, 23, false);
+    private DayLimit _dayStart = new(ApplicationState.DefaultStartHour, 0, true);
+    private DayLimit _dayEnd = new(ApplicationState.DefaultEndHour, 23, false);
 
     // The hours to render. These are reflecting the grids drawing state
     private Hour[]? _hours;
@@ -117,7 +117,7 @@
         else if (_selectedQuartersHead.Index < quarter.Index) // Going downwards
             SelectedQuarterIdRange = Enumerable.Range(_selectedQuartersHead.Index, quarter.Index - _selectedQuartersHead.Index + 1).ToArray();
         else
-            SelectedQuarterIdRange = new[] { quarter.Index };
+            SelectedQuarterIdRange = [quarter.Index];
 
         ClearStyleFromQuarters(previousRange);
         StyleSelectedQuarter(SelectedQuarterIdRange);

--- a/src/Quarter/Pages/Application/Timesheet/TimesheetGrid.razor
+++ b/src/Quarter/Pages/Application/Timesheet/TimesheetGrid.razor
@@ -8,7 +8,7 @@
     <div class="q-widget q-timesheet">
         <div class="q-timesheet-scroll q-timesheet-scroll--sod">
             <button class="q-button q-button--icon q-button--ghost"
-                    @onclick="OnStartOfDay"
+                    @onclick="OnStartOfDayAsync"
                     disabled="@_dayStart.LimitReached()"
                     test="start-of-day-action">
                 <svg class="q-icon--s">
@@ -45,7 +45,7 @@
 
         <div class="q-timesheet-scroll q-timesheet-scroll--eod">
             <button class="q-button q-button--icon q-button--ghost"
-                    @onclick="OnEndOfDay"
+                    @onclick="OnEndOfDayAsync"
                     disabled="@_dayEnd.LimitReached()"
                     test="end-of-day-action">
                 <svg class="q-icon--s">
@@ -82,17 +82,24 @@
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
+
+        if (State is not null)
+        {
+            _dayStart = new DayLimit(State.StartHourOfDay, 0, true);
+            _dayEnd = new DayLimit(State.EndHourOfDay, 23, false);
+        }
+
         GenerateHours();
     }
 
     internal IEnumerable<Hour> Hours()
         => _hours ?? GenerateHours();
 
-    private void OnStartOfDay()
-        => _dayStart.Extend();
+    private async Task OnStartOfDayAsync()
+        => await DispatchAsync(new ExtendStartOfDay());
 
-    private void OnEndOfDay()
-        => _dayEnd.Extend();
+    private async Task OnEndOfDayAsync()
+        => await DispatchAsync(new ExtendEndOfDay());
 
     internal void OnMouseDown(QuarterViewModel quarter)
     {
@@ -238,13 +245,13 @@
     {
         if (timesheet.FirstHourInUse is { } startHour)
         {
-            var hour = Math.Min(startHour, ApplicationState.DefaultStartHour);
+            var hour = Math.Min(startHour, State?.StartHourOfDay ?? 0);
             _dayStart = new DayLimit(hour, 0, true);
         }
 
         if (timesheet.LastHourInUse is { } endHour)
         {
-            var hour = Math.Max(endHour, ApplicationState.DefaultEndHour);
+            var hour = Math.Max(endHour, State?.EndHourOfDay ?? 0);
             _dayEnd = new DayLimit(hour, 23, false);
         }
     }

--- a/src/Quarter/State/ActionHandler.cs
+++ b/src/Quarter/State/ActionHandler.cs
@@ -66,6 +66,8 @@ public class ActionHandler(
             SelectEraseActivityAction a => HandleAsync(currentState, a, ct),
             SelectActivityAction a => HandleAsync(currentState, a, ct),
             TimeAction a => HandleAsync(currentState, a, ct),
+            ExtendStartOfDay a => HandleAsync(currentState, a, ct),
+
             _ => Task.FromResult(currentState) // This should be exhaustive - why is this required!
         };
         return await task;
@@ -557,6 +559,13 @@ public class ActionHandler(
         currentState.SelectedTimesheet = timesheet;
 
         return currentState;
+    }
+
+    private static Task<ApplicationState> HandleAsync(ApplicationState currentState, ExtendStartOfDay action, CancellationToken ct)
+    {
+        if (currentState.StartHourOfDay > 0)
+            currentState.StartHourOfDay -= 1;
+        return Task.FromResult(currentState);
     }
 
     private async Task<OperationContext> OperationContextForCurrentUser()

--- a/src/Quarter/State/ActionHandler.cs
+++ b/src/Quarter/State/ActionHandler.cs
@@ -67,6 +67,7 @@ public class ActionHandler(
             SelectActivityAction a => HandleAsync(currentState, a, ct),
             TimeAction a => HandleAsync(currentState, a, ct),
             ExtendStartOfDay a => HandleAsync(currentState, a, ct),
+            ExtendEndOfDay a => HandleAsync(currentState, a, ct),
 
             _ => Task.FromResult(currentState) // This should be exhaustive - why is this required!
         };
@@ -565,6 +566,13 @@ public class ActionHandler(
     {
         if (currentState.StartHourOfDay > 0)
             currentState.StartHourOfDay -= 1;
+        return Task.FromResult(currentState);
+    }
+
+    private static Task<ApplicationState> HandleAsync(ApplicationState currentState, ExtendEndOfDay action, CancellationToken ct)
+    {
+        if (currentState.EndHourOfDay < 23)
+            currentState.EndHourOfDay += 1;
         return Task.FromResult(currentState);
     }
 

--- a/src/Quarter/State/Actions.cs
+++ b/src/Quarter/State/Actions.cs
@@ -210,4 +210,9 @@ public record RegisterTimeAction(Date Date, TimeSlot Slot) : TimeAction(Date, Sl
 /// <param name="Slot">The time slot to erase</param>
 public record EraseTimeAction(Date Date, TimeSlot Slot) : TimeAction(Date, Slot);
 
+/// <summary>
+/// Extending the start of day with one hour, which is to move the start of day one hour earlier (if possible).
+/// </summary>
+public record ExtendStartOfDay : IAction;
+
 #endregion

--- a/src/Quarter/State/Actions.cs
+++ b/src/Quarter/State/Actions.cs
@@ -215,4 +215,9 @@ public record EraseTimeAction(Date Date, TimeSlot Slot) : TimeAction(Date, Slot)
 /// </summary>
 public record ExtendStartOfDay : IAction;
 
+/// <summary>
+/// Extending the end of day with one hour, which is to move the end of day one hour later (if possible).
+/// </summary>
+public record ExtendEndOfDay : IAction;
+
 #endregion

--- a/src/Quarter/State/ApplicationState.cs
+++ b/src/Quarter/State/ApplicationState.cs
@@ -32,6 +32,28 @@ public class ApplicationState
     public const int DefaultStartHour = 6;
     public const int DefaultEndHour = 18;
 
+    public int StartHourOfDay
+    {
+        get => _startHourOfDay;
+        set
+        {
+            if (value < 0) throw new ArgumentException("Start of day cannot be before midnight!");
+            if (value >= EndHourOfDay) throw new ArgumentException("Start of day must be before end of day!");
+            _startHourOfDay = value;
+        }
+    }
+
+    public int EndHourOfDay
+    {
+        get => _endHourOfDay;
+        set
+        {
+            if (value > 23) throw new ArgumentException("End of day cannot be after 11:th hour");
+            if (value <= StartHourOfDay) throw new ArgumentException("End of day must be after start of day!");
+            _endHourOfDay = value;
+        }
+    }
+
     public Stack<ModalState> Modals { get; } = new();
 
     public List<ProjectViewModel> Projects { get; set; } = new();
@@ -45,6 +67,9 @@ public class ApplicationState
     /// Usable during debugging
     /// </summary>
     public long StateChanges { get; set; }
+
+    private int _startHourOfDay = DefaultStartHour;
+    private int _endHourOfDay = DefaultEndHour;
 
     public void SafePopTopMostModal()
         => Modals.TryPop(out _);

--- a/test/unit/Quarter.UnitTest/Pages/Application/TimesheetPage/TimesheetGridTest.cs
+++ b/test/unit/Quarter.UnitTest/Pages/Application/TimesheetPage/TimesheetGridTest.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using AngleSharp.Css.Dom;
 using AngleSharp.Dom;
 using Bunit;
+using Microsoft.AspNetCore.Components.Web;
 using NUnit.Framework;
 using Quarter.Core.Models;
 using Quarter.Core.Utils;
@@ -63,18 +64,20 @@ public class TimesheetGridTest
 
         [Test]
         public void ItShouldStartOneHourEarlierThanDefault()
-            => Assert.That(RenderedHours()?.First(), Is.EqualTo("05:00"));
+        {
+            var action = StateManager.DispatchedActions.Single();
+            Assert.That(action, Is.InstanceOf(typeof(ExtendStartOfDay)));
+        }
     }
 
-    public class WhenClickingStartOfDayManyTimes : TestCase
+    public class WhenStartOfDayIsAtMinimumValue : TestCase
     {
         [OneTimeSetUp]
         public void Setup()
         {
             StateManager.State.SelectedTimesheet = Timesheet.CreateForDate(Date.Random());
+            StateManager.State.StartHourOfDay = 0;
             Render();
-            foreach (var _ in Enumerable.Range(0, 24))
-                StartOfDayAction()?.Click();
         }
 
         [Test]
@@ -98,18 +101,20 @@ public class TimesheetGridTest
 
         [Test]
         public void ItShouldEndOneHourLaterThanDefault()
-            => Assert.That(RenderedHours()?.Last(), Is.EqualTo("19:00"));
+        {
+            var action = StateManager.DispatchedActions.Single();
+            Assert.That(action, Is.InstanceOf(typeof(ExtendEndOfDay)));
+        }
     }
 
-    public class WhenClickingEndOfDayManyTimes : TestCase
+    public class WhenEndOfDayIsAtMaximumValue : TestCase
     {
         [OneTimeSetUp]
         public void Setup()
         {
             StateManager.State.SelectedTimesheet = Timesheet.CreateForDate(Date.Random());
+            StateManager.State.EndHourOfDay = 23;
             Render();
-            foreach (var _ in Enumerable.Range(0, 24))
-                EndOfDayAction()?.Click();
         }
 
         [Test]

--- a/test/unit/Quarter.UnitTest/State/AddProjectActionTest.cs
+++ b/test/unit/Quarter.UnitTest/State/AddProjectActionTest.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -27,13 +29,13 @@ public class AddProjectActionTest : ActionHandlerTestCase
     }
 
     [Test]
-    public void ItShouldPopTopMostModal()
+    public async Task ItShouldPopTopMostModal()
     {
         var state = NewState();
         state.Modals.Push(ModalState.ParameterLess(typeof(FakeModal)));
 
         var formData = new ProjectFormData { Name = "Alpha", Description = "Project A" };
-        ActionHandler.HandleAsync(state, new AddProjectAction(formData), CancellationToken.None);
+        _ = await ActionHandler.HandleAsync(state, new AddProjectAction(formData), CancellationToken.None);
 
         Assert.That(state.Modals, Is.Empty);
     }

--- a/test/unit/Quarter.UnitTest/State/ApplicationStateTest.cs
+++ b/test/unit/Quarter.UnitTest/State/ApplicationStateTest.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using NUnit.Framework;
+using Quarter.State;
+
+namespace Quarter.UnitTest.State;
+
+[TestFixture]
+public class ApplicationStateTest
+{
+    [Test]
+    public void ItShouldThrowWhenSettingStartOfDayToLessThanZero()
+    {
+        var state = new ApplicationState();
+        Assert.Throws<ArgumentException>(() => state.StartHourOfDay = -1);
+    }
+
+    [TestCase(12)]
+    [TestCase(11)]
+    public void ItShouldThrowWhenSettingStartOfDayToLessOrEqualThanEndOfDay(int sod)
+    {
+        var state = new ApplicationState
+        {
+            EndHourOfDay = 11
+        };
+        Assert.Throws<ArgumentException>(() => state.StartHourOfDay = sod);
+    }
+
+    [Test]
+    public void ItShouldThrowWhenSettingEndOfDayToGreaterThan23()
+    {
+        var state = new ApplicationState();
+        Assert.Throws<ArgumentException>(() => state.EndHourOfDay = 24);
+    }
+
+    [TestCase(12)]
+    [TestCase(11)]
+    public void ItShouldThrowWhenSettingEndOfDayToLessOrEqualThanStartOfDay(int eod)
+    {
+        var state = new ApplicationState
+        {
+            StartHourOfDay = 12
+        };
+        Assert.Throws<ArgumentException>(() => state.EndHourOfDay = eod);
+    }
+}

--- a/test/unit/Quarter.UnitTest/State/ExtendEndOfDayTest.cs
+++ b/test/unit/Quarter.UnitTest/State/ExtendEndOfDayTest.cs
@@ -1,0 +1,49 @@
+﻿#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Quarter.State;
+
+namespace Quarter.UnitTest.State;
+
+[TestFixture]
+public class ExtendEndOfDayTest
+{
+    [TestFixture]
+    public class WhenNotAtMidnight : ActionHandlerTestCase
+    {
+        private int _initialHour;
+        private ApplicationState _state = null!;
+
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            var state = NewState();
+            _initialHour = state.EndHourOfDay;
+            _state = await ActionHandler.HandleAsync(state, new ExtendEndOfDay(), CancellationToken.None);
+        }
+
+        [Test]
+        public void ItShouldHaveMovedTheHourForwardOneHour()
+            => Assert.That(_state.EndHourOfDay, Is.EqualTo(_initialHour + 1));
+    }
+
+    [TestFixture]
+    public class WhenAtMidnight : ActionHandlerTestCase
+    {
+        private ApplicationState _state = null!;
+
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            var state = NewState();
+            state.EndHourOfDay = 23;
+            _state = await ActionHandler.HandleAsync(state, new ExtendEndOfDay(), CancellationToken.None);
+        }
+
+        [Test]
+        public void ItShouldNotHaveChangedEndOfDay()
+            => Assert.That(_state.EndHourOfDay, Is.EqualTo(23));
+    }
+}

--- a/test/unit/Quarter.UnitTest/State/ExtendStartOfDayTest.cs
+++ b/test/unit/Quarter.UnitTest/State/ExtendStartOfDayTest.cs
@@ -1,0 +1,49 @@
+﻿#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Quarter.State;
+
+namespace Quarter.UnitTest.State;
+
+[TestFixture]
+public class ExtendStartOfDayTest
+{
+    [TestFixture]
+    public class WhenNotAtMidnight : ActionHandlerTestCase
+    {
+        private int _initialHour;
+        private ApplicationState _state = null!;
+
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            var state = NewState();
+            _initialHour = state.StartHourOfDay;
+            _state = await ActionHandler.HandleAsync(state, new ExtendStartOfDay(), CancellationToken.None);
+        }
+
+        [Test]
+        public void ItShouldHaveMovedTheHourBackOneHour()
+            => Assert.That(_state.StartHourOfDay, Is.EqualTo(_initialHour - 1));
+    }
+
+    [TestFixture]
+    public class WhenAtMidnight : ActionHandlerTestCase
+    {
+        private ApplicationState _state = null!;
+
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            var state = NewState();
+            state.StartHourOfDay = 0;
+            _state = await ActionHandler.HandleAsync(state, new ExtendStartOfDay(), CancellationToken.None);
+        }
+
+        [Test]
+        public void ItShouldNotHaveChangedStartOfDay()
+            => Assert.That(_state.StartHourOfDay, Is.EqualTo(0));
+    }
+}


### PR DESCRIPTION
Add start and end of day to the application state and use when render the timesheet. This fix #12 where the start/end is reset on navigation or even when selecting a new activity in the list of project and activities.

The possible downside is that the user need to do a full page refresh to restore to default values (06 and 18).