### PR TITLE
Random colours!

### DIFF
--- a/service/src/Quarter.Core/Commands/CommandHandler.cs
+++ b/service/src/Quarter.Core/Commands/CommandHandler.cs
@@ -66,7 +66,7 @@ public class CommandHandler(IRepositoryFactory repositoryFactory) : ICommandHand
 
     private async Task ExecuteAsync(AddProjectCommand command, OperationContext oc, CancellationToken ct)
     {
-        var project = new Project(command.Name, command.Description);
+        var project = new Project(command.Name, command.Description, command.Color);
         await repositoryFactory.ProjectRepository(oc.UserId).CreateAsync(project, ct);
     }
 
@@ -79,6 +79,8 @@ public class CommandHandler(IRepositoryFactory repositoryFactory) : ICommandHand
                     current.Name = command.Name;
                 if (command.Description is not null)
                     current.Description = command.Description;
+                if (command.Color is not null)
+                    current.Color = command.Color;
 
                 return current;
             }, ct);

--- a/service/src/Quarter.Core/Commands/ProjectCommands.cs
+++ b/service/src/Quarter.Core/Commands/ProjectCommands.cs
@@ -3,8 +3,8 @@ using Quarter.Core.Utils;
 
 namespace Quarter.Core.Commands;
 
-public record AddProjectCommand(string Name, string Description) : ICommand;
-public record EditProjectCommand(IdOf<Project> ProjectId, string? Name, string? Description) : ICommand;
+public record AddProjectCommand(string Name, string Description, Color Color) : ICommand;
+public record EditProjectCommand(IdOf<Project> ProjectId, string? Name, string? Description, Color? Color) : ICommand;
 public record RemoveProjectCommand(IdOf<Project> ProjectId) : ICommand;
 public record ArchiveProjectCommand(IdOf<Project> ProjectId) : ICommand;
 public record RestoreProjectCommand(IdOf<Project> ProjectId) : ICommand;

--- a/service/src/Quarter.Core/Models/Project.cs
+++ b/service/src/Quarter.Core/Models/Project.cs
@@ -6,20 +6,34 @@ namespace Quarter.Core.Models;
 
 public class Project : IAggregate<Project>
 {
+    /// <summary>
+    /// Default color used for projects created before the color feature was added.
+    /// </summary>
+    public static readonly Color DefaultColor = Color.FromHexString("#457b9d");
+
     [JsonConverter(typeof(IdOfJsonConverter<Project>))]
     public IdOf<Project> Id { get; set; }
     public UtcDateTime Created { get; set; }
     public UtcDateTime? Updated { get; set; }
     public string Name { get; set; }
     public string Description { get; set; }
+
+    private Color? _color;
+    public Color Color
+    {
+        get => _color ?? DefaultColor;
+        set => _color = value;
+    }
+
     public bool IsArchived { get; set; }
 
-    public Project(string name, string description)
+    public Project(string name, string description, Color color)
     {
         Id = IdOf<Project>.Random();
         Created = UtcDateTime.Now();
         Name = name;
         Description = description;
+        Color = color;
     }
 
 #pragma warning disable CS8618
@@ -46,9 +60,10 @@ public class Project : IAggregate<Project>
                Description == other.Description &&
                Created.DateTime == other.Created.DateTime &&
                Updated?.DateTime == other.Updated?.DateTime &&
+               Color.Equals(other.Color) &&
                IsArchived == other.IsArchived;
     }
 
     public override int GetHashCode()
-        => HashCode.Combine(Id, Name, Description, Created, Updated, IsArchived);
+        => HashCode.Combine(Id, Name, Description, Created, Updated, Color, IsArchived);
 }

--- a/service/src/Quarter.Core/Repositories/ProjectRepository.cs
+++ b/service/src/Quarter.Core/Repositories/ProjectRepository.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
 using Quarter.Core.Models;
+using Quarter.Core.Utils;
 
 namespace Quarter.Core.Repositories;
 
@@ -16,7 +17,7 @@ public static class ProjectRepository
 {
     public static Task<Project> CreateSandboxProjectAsync(IProjectRepository self, CancellationToken ct)
     {
-        var project = new Project("Your first project", "A project is used to group activities.");
+        var project = new Project("Your first project", "A project is used to group activities.", Color.FromHexString("#457b9d"));
         return self.CreateAsync(project, ct);
     }
 }

--- a/service/src/Quarter.HttpApi/Resources/ProjectResource.cs
+++ b/service/src/Quarter.HttpApi/Resources/ProjectResource.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Quarter.Core.Models;
+using Quarter.Core.Utils;
 
 namespace Quarter.HttpApi.Resources;
 
@@ -11,17 +12,18 @@ namespace Quarter.HttpApi.Resources;
 /// <param name="id">The ID of the project</param>
 /// <param name="name">The name of the project</param>
 /// <param name="description">The project description</param>
+/// <param name="color">The project color in CSS HEX</param>
 /// <param name="isArchived">Whether or not the project is archived</param>
 /// <param name="created">Timestamp for when the project was created (ISO-8601)</param>
 /// <param name="updated">Timestamp for when the project was last updated, or null if it has never been updated (ISO-8601)</param>
-public record ProjectResourceOutput(string id, string name, string description, bool isArchived, string created, string? updated)
+public record ProjectResourceOutput(string id, string name, string description, string color, bool isArchived, string created, string? updated)
 {
     public Uri Location()
         => new($"/api/projects/{id}", UriKind.Relative);
 
     public static ProjectResourceOutput From(Project project)
     {
-        return new ProjectResourceOutput(project.Id.AsString(), project.Name, project.Description, project.IsArchived, project.Created.IsoString(), project.Updated?.IsoString());
+        return new ProjectResourceOutput(project.Id.AsString(), project.Name, project.Description, project.Color.ToHex(), project.IsArchived, project.Created.IsoString(), project.Updated?.IsoString());
     }
 }
 
@@ -31,6 +33,9 @@ public class CreateProjectResourceInput
     public string? name { get; set; }
 
     public string? description { get; set; }
+
+    [RegularExpression("^#([0-9a-fA-F]{3}){1,2}$", ErrorMessage = "The color field is invalid, must be a HEX value (e.g. #04a85b).")]
+    public string? color { get; set; }
 }
 
 public class UpdateProjectResourceInput
@@ -38,6 +43,9 @@ public class UpdateProjectResourceInput
     public string? name { get; set; }
 
     public string? description { get; set; }
+
+    [RegularExpression("^#([0-9a-fA-F]{3}){1,2}$", ErrorMessage = "The color field is invalid, must be a HEX value (e.g. #04a85b).")]
+    public string? color { get; set; }
 
     public bool? isArchived { get; set; }
 }

--- a/service/src/Quarter.HttpApi/Services/ApiService.cs
+++ b/service/src/Quarter.HttpApi/Services/ApiService.cs
@@ -43,7 +43,8 @@ public class ApiService(IRepositoryFactory repositoryFactory, IQueryHandler quer
 
     public async Task<ProjectResourceOutput> CreateProjectAsync(CreateProjectResourceInput input, OperationContext oc, CancellationToken ct)
     {
-        var project = new Project(input.name!, input.description!);
+        var color = input.color is not null ? Color.FromHexString(input.color) : Project.DefaultColor;
+        var project = new Project(input.name!, input.description!, color);
         project = await repositoryFactory.ProjectRepository(oc.UserId).CreateAsync(project, ct);
         return ProjectResourceOutput.From(project);
     }
@@ -54,6 +55,7 @@ public class ApiService(IRepositoryFactory repositoryFactory, IQueryHandler quer
         {
             if (input.name is not null) existing.Name = input.name;
             if (input.description is not null) existing.Description = input.description;
+            if (input.color is not null) existing.Color = Color.FromHexString(input.color);
             if (input.isArchived is {} isArchived) existing.IsArchived = isArchived;
             return existing;
         }, ct);

--- a/service/test/unit/Quarter.Core.UnitTest/Commands/AddProjectCommandTest.cs
+++ b/service/test/unit/Quarter.Core.UnitTest/Commands/AddProjectCommandTest.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Quarter.Core.Commands;
+using Quarter.Core.Utils;
 
 namespace Quarter.Core.UnitTest.Commands;
 
@@ -14,7 +15,7 @@ public class AddProjectCommandTest : CommandTestBase
         [OneTimeSetUp]
         public async Task AddingProject()
         {
-            var command = new AddProjectCommand("Sample project", "Something");
+            var command = new AddProjectCommand("Sample project", "Something", Color.FromHexString("#457b9d"));
             await Handler.ExecuteAsync(command, OperationContext(), CancellationToken.None);
         }
 
@@ -27,6 +28,16 @@ public class AddProjectCommandTest : CommandTestBase
                 .ToListAsync();
 
             Assert.That(projects, Is.EquivalentTo(new[] { "Sample project" }));
+        }
+
+        [Test]
+        public async Task ItShouldHavePersistedTheColor()
+        {
+            var projects = await RepositoryFactory.ProjectRepository(ActingUser)
+                .GetAllAsync(CancellationToken.None)
+                .ToListAsync();
+
+            Assert.That(projects.Single().Color, Is.EqualTo(Color.FromHexString("#457b9d")));
         }
     }
 }

--- a/service/test/unit/Quarter.Core.UnitTest/Commands/ArchiveProjectCommandTest.cs
+++ b/service/test/unit/Quarter.Core.UnitTest/Commands/ArchiveProjectCommandTest.cs
@@ -32,7 +32,7 @@ public class ArchiveProjectCommandTest : CommandTestBase
         public async Task AddingInitialProject()
         {
             _projectRepository = RepositoryFactory.ProjectRepository(ActingUser);
-            _initialProject = await _projectRepository.CreateAsync(new Project("a", "a"), CancellationToken.None);
+            _initialProject = await _projectRepository.CreateAsync(new Project("a", "a", Color.FromHexString("#457b9d")), CancellationToken.None);
             var command = new ArchiveProjectCommand(_initialProject.Id);
 
             await Handler.ExecuteAsync(command, OperationContext(), CancellationToken.None);

--- a/service/test/unit/Quarter.Core.UnitTest/Commands/CommandTestBase.cs
+++ b/service/test/unit/Quarter.Core.UnitTest/Commands/CommandTestBase.cs
@@ -33,7 +33,7 @@ namespace Quarter.Core.UnitTest.Commands
         protected Task<Project> CreateProjectAsync(string name)
         {
             var repo = RepositoryFactory.ProjectRepository(ActingUser);
-            return repo.CreateAsync(new Project(name, $"Description for {name}"), CancellationToken.None);
+            return repo.CreateAsync(new Project(name, $"Description for {name}", Color.FromHexString("#457b9d")), CancellationToken.None);
         }
 
         protected Task<Activity> CreateActivityAsync(IdOf<Project> projectId, string name)

--- a/service/test/unit/Quarter.Core.UnitTest/Commands/EditProjectCommandTest.cs
+++ b/service/test/unit/Quarter.Core.UnitTest/Commands/EditProjectCommandTest.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Quarter.Core.Commands;
 using Quarter.Core.Exceptions;
 using Quarter.Core.Models;
+using Quarter.Core.Utils;
 
 namespace Quarter.Core.UnitTest.Commands;
 
@@ -16,7 +17,7 @@ public class EditProjectCommandTest : CommandTestBase
         [Test]
         public void ItShouldFail()
         {
-            var command = new EditProjectCommand(IdOf<Project>.Random(), null, null);
+            var command = new EditProjectCommand(IdOf<Project>.Random(), null, null, null);
             Assert.ThrowsAsync<NotFoundException>(() => Handler.ExecuteAsync(command, OperationContext(), CancellationToken.None));
         }
     }
@@ -42,9 +43,9 @@ public class EditProjectCommandTest : CommandTestBase
         public async Task ItShouldHaveFieldValue(string name, string description, string expectedName, string expectedDescription)
         {
             var projectRepository = RepositoryFactory.ProjectRepository(ActingUser);
-            var initialProject = await projectRepository.CreateAsync(new Project("Initial name", "Initial description"),
+            var initialProject = await projectRepository.CreateAsync(new Project("Initial name", "Initial description", Color.FromHexString("#457b9d")),
                 CancellationToken.None);
-            var command = new EditProjectCommand(initialProject.Id, name, description);
+            var command = new EditProjectCommand(initialProject.Id, name, description, null);
             await Handler.ExecuteAsync(command, OperationContext(), CancellationToken.None);
 
             var readProject = await projectRepository.GetByIdAsync(initialProject.Id, CancellationToken.None);
@@ -54,6 +55,39 @@ public class EditProjectCommandTest : CommandTestBase
                 Assert.That(readProject.Name, Is.EqualTo(expectedName));
                 Assert.That(readProject.Description, Is.EqualTo(expectedDescription));
             });
+        }
+    }
+
+    public class WhenEditingProjectColor : EditProjectCommandTest
+    {
+        [Test]
+        public async Task ItShouldUpdateColorWhenProvided()
+        {
+            var projectRepository = RepositoryFactory.ProjectRepository(ActingUser);
+            var initialProject = await projectRepository.CreateAsync(
+                new Project("Name", "Desc", Color.FromHexString("#457b9d")), CancellationToken.None);
+
+            var newColor = Color.FromHexString("#e63946");
+            var command = new EditProjectCommand(initialProject.Id, null, null, newColor);
+            await Handler.ExecuteAsync(command, OperationContext(), CancellationToken.None);
+
+            var readProject = await projectRepository.GetByIdAsync(initialProject.Id, CancellationToken.None);
+            Assert.That(readProject.Color, Is.EqualTo(newColor));
+        }
+
+        [Test]
+        public async Task ItShouldNotChangeColorWhenNull()
+        {
+            var projectRepository = RepositoryFactory.ProjectRepository(ActingUser);
+            var originalColor = Color.FromHexString("#457b9d");
+            var initialProject = await projectRepository.CreateAsync(
+                new Project("Name", "Desc", originalColor), CancellationToken.None);
+
+            var command = new EditProjectCommand(initialProject.Id, "New name", null, null);
+            await Handler.ExecuteAsync(command, OperationContext(), CancellationToken.None);
+
+            var readProject = await projectRepository.GetByIdAsync(initialProject.Id, CancellationToken.None);
+            Assert.That(readProject.Color, Is.EqualTo(originalColor));
         }
     }
 }

--- a/service/test/unit/Quarter.Core.UnitTest/Commands/RemoveProjectCommandTest.cs
+++ b/service/test/unit/Quarter.Core.UnitTest/Commands/RemoveProjectCommandTest.cs
@@ -32,7 +32,7 @@ public class RemoveProjectCommandTest : CommandTestBase
         public async Task AddingInitialProject()
         {
             _projectRepository = RepositoryFactory.ProjectRepository(ActingUser);
-            _initialProject = await _projectRepository.CreateAsync(new Project("a", "a"), CancellationToken.None);
+            _initialProject = await _projectRepository.CreateAsync(new Project("a", "a", Color.FromHexString("#457b9d")), CancellationToken.None);
             var command = new RemoveProjectCommand(_initialProject.Id);
 
             await Handler.ExecuteAsync(command, OperationContext(), CancellationToken.None);

--- a/service/test/unit/Quarter.Core.UnitTest/Commands/RestoreProjectCommandTest.cs
+++ b/service/test/unit/Quarter.Core.UnitTest/Commands/RestoreProjectCommandTest.cs
@@ -5,6 +5,7 @@ using Quarter.Core.Commands;
 using Quarter.Core.Exceptions;
 using Quarter.Core.Models;
 using Quarter.Core.Repositories;
+using Quarter.Core.Utils;
 
 namespace Quarter.Core.UnitTest.Commands;
 
@@ -30,7 +31,7 @@ public class RestoreProjectCommandTest : CommandTestBase
         public async Task AddingInitialProject()
         {
             _projectRepository = RepositoryFactory.ProjectRepository(ActingUser);
-            var project = new Project("a", "a");
+            var project = new Project("a", "a", Color.FromHexString("#457b9d"));
             project.Archive();
             _initialProject = await _projectRepository.CreateAsync(project, CancellationToken.None);
             var command = new RestoreProjectCommand(_initialProject.Id);

--- a/service/test/unit/Quarter.Core.UnitTest/Models/ProjectTest.cs
+++ b/service/test/unit/Quarter.Core.UnitTest/Models/ProjectTest.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using Quarter.Core.Models;
+using Quarter.Core.Utils;
 
 namespace Quarter.Core.UnitTest.Models
 {
@@ -8,7 +9,7 @@ namespace Quarter.Core.UnitTest.Models
     {
         public class WhenConstructed
         {
-            private readonly Project _project = new Project("Alpha", "Alpha:Description");
+            private readonly Project _project = new Project("Alpha", "Alpha:Description", Color.FromHexString("#457b9d"));
 
             [Test]
             public void ItShouldHaveName()
@@ -17,6 +18,10 @@ namespace Quarter.Core.UnitTest.Models
             [Test]
             public void ItShouldHaveDescription()
                 => Assert.That(_project.Description, Is.EqualTo("Alpha:Description"));
+
+            [Test]
+            public void ItShouldHaveColor()
+                => Assert.That(_project.Color, Is.EqualTo(Color.FromHexString("#457b9d")));
 
             [Test]
             public void ItShouldGetAnIdAssigned()
@@ -37,7 +42,7 @@ namespace Quarter.Core.UnitTest.Models
 
         public class WhenArchived
         {
-            private readonly Project _project = new Project("Alpha", "Alpha:Description");
+            private readonly Project _project = new Project("Alpha", "Alpha:Description", Color.FromHexString("#457b9d"));
 
             [OneTimeSetUp]
             public void WhenArchivedSetUp()
@@ -52,7 +57,7 @@ namespace Quarter.Core.UnitTest.Models
 
         public class WhenRestored
         {
-            private readonly Project _project = new Project("Alpha", "Alpha:Description");
+            private readonly Project _project = new Project("Alpha", "Alpha:Description", Color.FromHexString("#457b9d"));
 
             [OneTimeSetUp]
             public void WhenRestoredSetUp()

--- a/service/test/unit/Quarter.Core.UnitTest/Repositories/ProjectRepositoryTest.cs
+++ b/service/test/unit/Quarter.Core.UnitTest/Repositories/ProjectRepositoryTest.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using Quarter.Core.Models;
 using Quarter.Core.Repositories;
 using Quarter.Core.UnitTest.TestUtils;
+using Quarter.Core.Utils;
 
 namespace Quarter.Core.UnitTest.Repositories
 {
@@ -17,7 +18,7 @@ namespace Quarter.Core.UnitTest.Repositories
         protected override Project ArbitraryAggregate()
         {
             var id = Guid.NewGuid();
-            return new Project($"Name {id}", $"Description {id}");
+            return new Project($"Name {id}", $"Description {id}", Color.FromHexString("#457b9d"));
         }
 
         protected override Project WithoutTimestamps(Project aggregate)

--- a/service/test/unit/Quarter.Core.UnitTest/Repositories/RepositoryFactoryTest.cs
+++ b/service/test/unit/Quarter.Core.UnitTest/Repositories/RepositoryFactoryTest.cs
@@ -159,7 +159,7 @@ public abstract class RepositoryAccessTestBase
     }
 
     private static Project ArbitraryProject()
-        => new Project("Arbitrary", "Arbitrary");
+        => new Project("Arbitrary", "Arbitrary", Color.FromHexString("#457b9d"));
 
     private static Activity ArbitraryActivity()
         => new Activity(IdOf<Project>.Random(), "Arbitrary", "Arbitrary", Color.FromHexString("#000"));

--- a/service/test/unit/Quarter.HttpApi.UnitTest/Resources/CreateProjectResourceInputTest.cs
+++ b/service/test/unit/Quarter.HttpApi.UnitTest/Resources/CreateProjectResourceInputTest.cs
@@ -14,6 +14,7 @@ public class CreateProjectResourceInputTest
     {
         public static IEnumerable<object[]> ValidResources()
         {
+            yield return [new CreateProjectResourceInput { name = "OK", description = "OK", color = "#457b9d" }];
             yield return [new CreateProjectResourceInput { name = "OK", description = "OK" }];
         }
 
@@ -36,8 +37,9 @@ public class CreateProjectResourceInputTest
     {
         public static IEnumerable<object[]> InvalidResources()
         {
-            yield return [new CreateProjectResourceInput { name = null! }, "The name field is required."];
-            yield return [new CreateProjectResourceInput { name = "" }, "The name field is required."];
+            yield return [new CreateProjectResourceInput { name = null!, color = "#457b9d" }, "The name field is required."];
+            yield return [new CreateProjectResourceInput { name = "", color = "#457b9d" }, "The name field is required."];
+            yield return [new CreateProjectResourceInput { name = "OK", color = "invalid" }, "The color field is invalid, must be a HEX value (e.g. #04a85b)."];
         }
 
         [TestCaseSource(nameof(InvalidResources))]

--- a/service/test/unit/Quarter.HttpApi.UnitTest/Resources/ProjectResourceOutputTest.cs
+++ b/service/test/unit/Quarter.HttpApi.UnitTest/Resources/ProjectResourceOutputTest.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using Quarter.Core.Models;
 using Quarter.Core.Utils;
 using Quarter.HttpApi.Resources;
+using Color = Quarter.Core.Utils.Color;
 
 namespace Quarter.HttpApi.UnitTest.Resources;
 
@@ -17,7 +18,7 @@ public class ProjectResourceOutputTest
         [OneTimeSetUp]
         public void Setup()
         {
-            _project = new Project("Project name", "Project description");
+            _project = new Project("Project name", "Project description", Color.FromHexString("#457b9d"));
             _output = ProjectResourceOutput.From(_project);
         }
 
@@ -32,6 +33,10 @@ public class ProjectResourceOutputTest
         [Test]
         public void ItShouldMapDescription()
             => Assert.That(_output?.description, Is.EqualTo("Project description"));
+
+        [Test]
+        public void ItShouldMapColor()
+            => Assert.That(_output?.color, Is.EqualTo("#457B9D"));
 
         [Test]
         public void ItShouldMapIsArchived()
@@ -55,7 +60,7 @@ public class ProjectResourceOutputTest
         [OneTimeSetUp]
         public void Setup()
         {
-            _project = new Project("Project name", "Project description");
+            _project = new Project("Project name", "Project description", Color.FromHexString("#457b9d"));
             _project.Updated = UtcDateTime.Now();
             _project.Archive();
             _output = ProjectResourceOutput.From(_project);

--- a/service/test/unit/Quarter.HttpApi.UnitTest/Resources/UpdateProjectResourceInputTest.cs
+++ b/service/test/unit/Quarter.HttpApi.UnitTest/Resources/UpdateProjectResourceInputTest.cs
@@ -16,6 +16,8 @@ public class UpdateProjectResourceInputTest
         {
             yield return [new UpdateProjectResourceInput { name = "OK", description = "OK" }];
             yield return [new UpdateProjectResourceInput { name = "OK", isArchived = true}];
+            yield return [new UpdateProjectResourceInput { name = "OK", color = "#457b9d" }];
+            yield return [new UpdateProjectResourceInput { name = "OK", color = "#FFF" }];
         }
 
         [TestCaseSource(nameof(ValidResources))]
@@ -28,6 +30,29 @@ public class UpdateProjectResourceInputTest
             {
                 Assert.That(result, Is.True);
                 Assert.That(errorMessages, Is.Empty);
+            });
+        }
+    }
+
+    [TestFixture]
+    public class WithInvalidInput
+    {
+        public static IEnumerable<object[]> InvalidResources()
+        {
+            yield return [new UpdateProjectResourceInput { name = "OK", color = "invalid" }, "The color field is invalid, must be a HEX value (e.g. #04a85b)."];
+            yield return [new UpdateProjectResourceInput { name = "OK", color = "457b9d" }, "The color field is invalid, must be a HEX value (e.g. #04a85b)."];
+        }
+
+        [TestCaseSource(nameof(InvalidResources))]
+        public void ItShouldNotBeValid(UpdateProjectResourceInput input, string expectedError)
+        {
+            var result = ObjectValidator.IsValid(input, out var errors);
+            var errorMessages = errors.Select(_ => _.ErrorMessage);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.False);
+                Assert.That(errorMessages, Does.Contain(expectedError));
             });
         }
     }

--- a/service/test/unit/Quarter.HttpApi.UnitTest/Services/ApiService/CreateProjectTest.cs
+++ b/service/test/unit/Quarter.HttpApi.UnitTest/Services/ApiService/CreateProjectTest.cs
@@ -22,7 +22,8 @@ public class CreateProjectTest
             var input = new CreateProjectResourceInput
             {
                 name = "Project alpha",
-                description = "Description alpha"
+                description = "Description alpha",
+                color = "#457b9d"
             };
             _output = await ApiService.CreateProjectAsync(input, _oc, CancellationToken.None);
         }
@@ -32,11 +33,22 @@ public class CreateProjectTest
             => Assert.That(_output?.name, Is.EqualTo("Project alpha"));
 
         [Test]
+        public void ItShouldReturnOutputResourceWithColor()
+            => Assert.That(_output?.color, Is.EqualTo("#457B9D"));
+
+        [Test]
         public async Task ItShouldHaveCreatedProject()
         {
             var projects = await ReadProjectsAsync(_oc.UserId);
             var projectNames = projects.Select(p => p.Name);
             Assert.That(projectNames, Is.EqualTo(new[] { "Project alpha" }));
+        }
+
+        [Test]
+        public async Task ItShouldHavePersistedProjectColor()
+        {
+            var projects = await ReadProjectsAsync(_oc.UserId);
+            Assert.That(projects.Single().Color, Is.EqualTo(Color.FromHexString("#457b9d")));
         }
     }
 }

--- a/service/test/unit/Quarter.HttpApi.UnitTest/Services/ApiService/TestCase.cs
+++ b/service/test/unit/Quarter.HttpApi.UnitTest/Services/ApiService/TestCase.cs
@@ -33,7 +33,7 @@ public class TestCase
     }
     protected Task<Project> AddProject(IdOf<User> userId, string name)
     {
-        var project = new Project(name, $"description:{name}");
+        var project = new Project(name, $"description:{name}", Color.FromHexString("#457b9d"));
         return _repositoryFactory.ProjectRepository(userId).CreateAsync(project, CancellationToken.None);
     }
 

--- a/service/test/unit/Quarter.HttpApi.UnitTest/Services/ApiService/UpdateProjectTest.cs
+++ b/service/test/unit/Quarter.HttpApi.UnitTest/Services/ApiService/UpdateProjectTest.cs
@@ -42,11 +42,69 @@ public class UpdateProjectTest
     }
 
     [TestFixture]
+    public class WhenUpdatingColor : TestCase
+    {
+        private readonly OperationContext _oc = CreateOperationContext();
+        private ProjectResourceOutput? _output;
+
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            var project = await AddProject(_oc.UserId, "Project Beta");
+            var input = new UpdateProjectResourceInput
+            {
+                color = "#e63946"
+            };
+            _output = await ApiService.UpdateProjectAsync(project.Id, input, _oc, CancellationToken.None);
+        }
+
+        [Test]
+        public void ItShouldReturnUpdatedColor()
+            => Assert.That(_output?.color, Is.EqualTo("#E63946"));
+
+        [Test]
+        public async Task ItShouldHavePersistedUpdatedColor()
+        {
+            var projects = await ReadProjectsAsync(_oc.UserId);
+            var project = projects.Single();
+            Assert.That(project.Color, Is.EqualTo(Color.FromHexString("#e63946")));
+        }
+    }
+
+    [TestFixture]
+    public class WhenColorIsOmitted : TestCase
+    {
+        private readonly OperationContext _oc = CreateOperationContext();
+        private ProjectResourceOutput? _output;
+
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            var project = await AddProject(_oc.UserId, "Project Gamma");
+            var input = new UpdateProjectResourceInput
+            {
+                name = "Project Gamma Updated"
+            };
+            _output = await ApiService.UpdateProjectAsync(project.Id, input, _oc, CancellationToken.None);
+        }
+
+        [Test]
+        public void ItShouldReturnOriginalColor()
+            => Assert.That(_output?.color, Is.EqualTo("#457B9D"));
+
+        [Test]
+        public async Task ItShouldNotHaveChangedColor()
+        {
+            var projects = await ReadProjectsAsync(_oc.UserId);
+            var project = projects.Single();
+            Assert.That(project.Color, Is.EqualTo(Color.FromHexString("#457b9d")));
+        }
+    }
+
+    [TestFixture]
     public class WhenArchiving : TestCase
     {
         private readonly OperationContext _oc = CreateOperationContext();
-
-        private ProjectResourceOutput? _output;
 
         [OneTimeSetUp]
         public async Task Setup()

--- a/service/test/unit/Quarter.UnitTest/HttpApi/CreateProjectTest.cs
+++ b/service/test/unit/Quarter.UnitTest/HttpApi/CreateProjectTest.cs
@@ -23,6 +23,7 @@ public class CreateProjectTest
             {
                 name = "Test name",
                 description = "Test description",
+                color = "#457b9d",
             };
             _response = await PostAsync("/api/projects/", payload);
         }
@@ -80,6 +81,7 @@ public class CreateProjectTest
             {
                 name = "Test name",
                 description = "Test description",
+                color = "#457b9d",
             };
             _response = await PostAsync("/api/projects/", payload);
         }

--- a/service/test/unit/Quarter.UnitTest/TestUtils/HttpTestCase.cs
+++ b/service/test/unit/Quarter.UnitTest/TestUtils/HttpTestCase.cs
@@ -61,7 +61,7 @@ public class HttpTestCase
     protected Task<Project> AddProjectAsync(IdOf<User> userId, string name)
     {
         var repoFactory = HttpTestSession.ResolveService<IRepositoryFactory>();
-        var project = new Project(name, $"description:{name}");
+        var project = new Project(name, $"description:{name}", Color.FromHexString("#457b9d"));
         return repoFactory.ProjectRepository(userId).CreateAsync(project, CancellationToken.None);
     }
 

--- a/webapp/src/dialogs/activity_dialog.gleam
+++ b/webapp/src/dialogs/activity_dialog.gleam
@@ -1,6 +1,7 @@
 import domain/color
 import domain/input_value.{type InputValue}
 import domain/project
+import gleam/list
 import gleam/string
 import types.{type FormValue}
 
@@ -13,12 +14,25 @@ pub type State {
   )
 }
 
-/// Create the dialog state for creating a new activity. I.e. an empty state.
-pub fn new() -> State {
+/// Create the dialog state for creating a new activity.
+/// The first activity in a project gets the project's color.
+/// Each subsequent activity darkens the last activity's color by 10%.
+pub fn new(project: project.Project) -> State {
+  let activity_color = case
+    project.activities
+    |> project.sort_activities()
+    |> list.last()
+  {
+    // Darken the last activity's color by 10%
+    Ok(last_activity) -> color.darken_by(last_activity.color, 0.1)
+    // No activities yet, use the project's color
+    Error(_) -> project.color
+  }
+
   State(
     input_value.ValidValue(""),
     input_value.ValidValue(""),
-    input_value.ValidValue(color.Color(142, 135, 245)),
+    input_value.ValidValue(activity_color),
     False,
   )
 }

--- a/webapp/src/dialogs/project_dialog.gleam
+++ b/webapp/src/dialogs/project_dialog.gleam
@@ -1,3 +1,4 @@
+import domain/color
 import domain/input_value.{type InputValue}
 import domain/project
 import gleam/string
@@ -7,13 +8,20 @@ pub type State {
   State(
     name: InputValue(String),
     description: InputValue(String),
+    color: InputValue(color.Color),
     is_valid: Bool,
   )
 }
 
 /// Create the dialog state for creating a new project. I.e. an empty state.
+/// The color is set to a random major color.
 pub fn new() -> State {
-  State(input_value.ValidValue(""), input_value.ValidValue(""), False)
+  State(
+    input_value.ValidValue(""),
+    input_value.ValidValue(""),
+    input_value.ValidValue(color.random_major_color()),
+    False,
+  )
 }
 
 /// Create the dialog state for editing a project.
@@ -21,6 +29,7 @@ pub fn edit(project: project.Project) -> State {
   State(
     input_value.ValidValue(project.name),
     input_value.ValidValue(project.description),
+    input_value.ValidValue(project.color),
     False,
   )
 }
@@ -31,6 +40,20 @@ pub fn update(state: State, value: FormValue) -> State {
       validate(State(..state, name: input_value.ValidValue(value.value)))
     "description" ->
       validate(State(..state, description: input_value.ValidValue(value.value)))
+    "color" -> {
+      case color.from_hex(value.value) {
+        Ok(c) -> validate(State(..state, color: input_value.ValidValue(c)))
+        Error(_) ->
+          validate(
+            State(
+              ..state,
+              color: input_value.InvalidValue(color.Color(0, 0, 0), [
+                "Invalid color",
+              ]),
+            ),
+          )
+      }
+    }
     _ -> state
   }
 }
@@ -46,5 +69,10 @@ pub fn validate(state: State) -> State {
     _ -> False
   }
 
-  State(..state, is_valid: name_valid && description_valid)
+  let color_valid = case state.color {
+    input_value.ValidValue(_) -> True
+    _ -> False
+  }
+
+  State(..state, is_valid: name_valid && description_valid && color_valid)
 }

--- a/webapp/src/domain/color.gleam
+++ b/webapp/src/domain/color.gleam
@@ -1,5 +1,6 @@
 import gleam/float
 import gleam/int
+import gleam/list
 import gleam/string
 
 /// Represents a RGBA color
@@ -10,21 +11,73 @@ pub type Color {
 }
 
 pub fn darken(color: Color) -> Color {
-  // Math.round(Math.min(Math.max(0, c + (c * lum)), 255))
-  let lum = -0.3
+  darken_by(color, 0.3)
+}
+
+/// Darken the color by the given percentage (0.0 to 1.0).
+/// E.g. darken_by(color, 0.1) darkens by 10%.
+pub fn darken_by(color: Color, percentage: Float) -> Color {
+  let amount = 1.0 -. percentage
   let r_float = int.to_float(color.r)
   let g_float = int.to_float(color.g)
   let b_float = int.to_float(color.b)
 
-  let rr = float.add(r_float, float.multiply(r_float, lum))
-  let gg = float.add(g_float, float.multiply(g_float, lum))
-  let bb = float.add(b_float, float.multiply(b_float, lum))
+  let rr = float.multiply(r_float, amount)
+  let gg = float.multiply(g_float, amount)
+  let bb = float.multiply(b_float, amount)
 
   let r = float.round(float.min(float.max(0.0, rr), 255.0))
   let g = float.round(float.min(float.max(0.0, gg), 255.0))
   let b = float.round(float.min(float.max(0.0, bb), 255.0))
 
   Color(r, g, b)
+}
+
+/// A curated palette of visually distinct major colors.
+/// These are chosen to be clearly distinguishable from each other.
+const major_colors = [
+  Color(230, 57, 70),
+  // Red
+  Color(244, 162, 97),
+  // Orange
+  Color(233, 196, 106),
+  // Yellow
+  Color(42, 157, 143),
+  // Teal
+  Color(38, 70, 83),
+  // Dark Blue
+  Color(69, 123, 157),
+  // Steel Blue
+  Color(142, 68, 173),
+  // Purple
+  Color(39, 174, 96),
+  // Green
+  Color(231, 76, 60),
+  // Vermilion
+  Color(52, 152, 219),
+  // Sky Blue
+  Color(211, 84, 0),
+  // Burnt Orange
+  Color(22, 160, 133),
+  // Dark Cyan
+  Color(192, 57, 43),
+  // Dark Red
+  Color(41, 128, 185),
+  // Ocean Blue
+  Color(142, 135, 245),
+  // Lavender
+  Color(230, 126, 34),
+  // Carrot Orange
+]
+
+/// Returns a random color from a curated palette of visually distinct major colors.
+pub fn random_major_color() -> Color {
+  let index = int.random(list.length(major_colors))
+  case list.drop(major_colors, index) {
+    [color, ..] -> color
+    // Fallback should never happen
+    [] -> Color(142, 135, 245)
+  }
 }
 
 pub fn color_to_style_value(c: Color) -> String {

--- a/webapp/src/domain/project.gleam
+++ b/webapp/src/domain/project.gleam
@@ -19,6 +19,7 @@ pub type Project {
     id: ProjectId,
     name: String,
     description: String,
+    color: color.Color,
     is_archived: Bool,
     created: Timestamp,
     updated: option.Option(Timestamp),

--- a/webapp/src/model.gleam
+++ b/webapp/src/model.gleam
@@ -242,7 +242,7 @@ pub fn edit_project_dialog(project: project.Project) {
 }
 
 pub fn new_activity_dialog(project: project.Project) {
-  AddActivityDialog(activity_dialog.new(), project)
+  AddActivityDialog(activity_dialog.new(project), project)
 }
 
 pub fn edit_activity_dialog(activity: project.Activity) {

--- a/webapp/src/protocol.gleam
+++ b/webapp/src/protocol.gleam
@@ -60,6 +60,7 @@ pub fn add_user(
 pub fn create_project(
   name: String,
   description: String,
+  color_value: color.Color,
   on_response handle_response: fn(Result(project.Project, rsvp.Error)) ->
     message.Msg,
 ) -> Effect(message.Msg) {
@@ -69,6 +70,7 @@ pub fn create_project(
     json.object([
       #("name", json.string(name)),
       #("description", json.string(description)),
+      #("color", json.string(color.to_hex(color_value))),
     ])
 
   rsvp.post(url, payload, handler)
@@ -78,6 +80,7 @@ pub fn update_project(
   project: project.Project,
   name: String,
   description: String,
+  color_value: color.Color,
   on_response handle_response: fn(Result(project.Project, rsvp.Error)) ->
     message.Msg,
 ) -> Effect(message.Msg) {
@@ -86,6 +89,7 @@ pub fn update_project(
     json.object([
       #("name", json.string(name)),
       #("description", json.string(description)),
+      #("color", json.string(color.to_hex(color_value))),
     ])
 
   rsvp.patch(project_url(project), payload, handler)
@@ -361,6 +365,7 @@ pub fn project_decoder() -> decode.Decoder(project.Project) {
   use id <- decode.field("id", decode.string)
   use name <- decode.field("name", decode.string)
   use description <- decode.field("description", decode.string)
+  use color_field <- decode.field("color", decode_color())
   use is_archived <- decode.field("isArchived", decode.bool)
   use created <- decode.field("created", decode_timestamp())
   use updated <- decode.optional_field(
@@ -374,6 +379,7 @@ pub fn project_decoder() -> decode.Decoder(project.Project) {
       project.ProjectId(id),
       name,
       description,
+      color_field,
       is_archived,
       created,
       updated,

--- a/webapp/src/views/manage_projects.gleam
+++ b/webapp/src/views/manage_projects.gleam
@@ -243,6 +243,12 @@ fn project_form(
     option.None -> "EditProjectDialog"
   }
 
+  let color_value = case state.color {
+    input_value.ValidValue(c) -> color.to_hex(c)
+    input_value.InvalidValue(c, _) -> color.to_hex(c)
+    input_value.UnvalidatedValue(c) -> color.to_hex(c)
+  }
+
   form.Form(
     id,
     [
@@ -254,6 +260,7 @@ fn project_form(
         True,
         False,
       ),
+      form.ColorInput("color", "Color", color_value, True, False),
     ],
     [
       form.Cancel,

--- a/webapp/src/webapp.gleam
+++ b/webapp/src/webapp.gleam
@@ -450,6 +450,7 @@ fn handle_dialog_confirm(m: model.Model) {
       protocol.create_project(
         state.name.value,
         state.description.value,
+        state.color.value,
         message.CreateProjectResult,
       )
 
@@ -458,6 +459,7 @@ fn handle_dialog_confirm(m: model.Model) {
         project,
         state.name.value,
         state.description.value,
+        state.color.value,
         message.UpdateProjectResult,
       )
 

--- a/webapp/test/dialogs/project_dialog_test.gleam
+++ b/webapp/test/dialogs/project_dialog_test.gleam
@@ -1,17 +1,26 @@
 import dialogs/project_dialog
+import domain/color
 import domain/input_value.{ValidValue}
 import gleam/list
 import gleeunit/should
 import test_util
+
+const valid_color = ValidValue(color.Color(69, 123, 157))
 
 pub fn should_be_valid_state_test() {
   let states = [
     project_dialog.State(
       ValidValue("My Project"),
       ValidValue("A description"),
+      valid_color,
       False,
     ),
-    project_dialog.State(ValidValue("My Project"), ValidValue(""), False),
+    project_dialog.State(
+      ValidValue("My Project"),
+      ValidValue(""),
+      valid_color,
+      False,
+    ),
   ]
 
   list.each(states, fn(state) {
@@ -22,8 +31,13 @@ pub fn should_be_valid_state_test() {
 
 pub fn should_be_invalid_test() {
   let states = [
-    project_dialog.State(ValidValue(""), ValidValue("A description"), True),
-    project_dialog.State(ValidValue(""), ValidValue(""), True),
+    project_dialog.State(
+      ValidValue(""),
+      ValidValue("A description"),
+      valid_color,
+      True,
+    ),
+    project_dialog.State(ValidValue(""), ValidValue(""), valid_color, True),
   ]
 
   list.each(states, fn(state) {

--- a/webapp/test/protocol/project_and_activities_decoder_test.gleam
+++ b/webapp/test/protocol/project_and_activities_decoder_test.gleam
@@ -26,12 +26,14 @@ pub fn inflates_to_child_less_projects_test() {
         \"id\": \"P01\",
         \"name\": \"Project Alpha\",
         \"description\": \"The alpha project\",
+        \"color\": \"#457B9D\",
         \"isArchived\": false,
         \"created\": \"2025-11-04T16:49:39.2993437Z\"
      },{
         \"id\": \"P02\",
         \"name\": \"Project Bravo\",
         \"description\": \"The bravo project\",
+        \"color\": \"#457B9D\",
         \"isArchived\": false,
         \"created\": \"2025-11-04T16:49:39.2993437Z\"
     }],

--- a/webapp/test/protocol/project_decoder_test.gleam
+++ b/webapp/test/protocol/project_decoder_test.gleam
@@ -1,3 +1,4 @@
+import domain/color
 import domain/project
 import gleam/json
 import gleam/option
@@ -15,6 +16,7 @@ pub fn decode_minimal_project_test() {
       \"id\": \"001\",
       \"name\": \"Project Alpha\",
       \"description\": \"\",
+      \"color\": \"#457B9D\",
       \"isArchived\": false,
       \"created\": \"2025-11-04T16:49:39.2993437Z\"
      }"
@@ -26,6 +28,7 @@ pub fn decode_minimal_project_test() {
         project.ProjectId("001"),
         "Project Alpha",
         "",
+        color.Color(69, 123, 157),
         False,
         result.unwrap(expected_created, tsutil.timestamp_zero()),
         option.None,
@@ -45,6 +48,7 @@ pub fn decode_full_project_test() {
       \"id\": \"001\",
       \"name\": \"Project Alpha\",
       \"description\": \"The alpha project\",
+      \"color\": \"#E63946\",
       \"isArchived\": true,
       \"created\": \"2025-11-04T16:49:39.2993437Z\",
       \"updated\": \"2025-11-04T20:00:00.0Z\"
@@ -57,6 +61,7 @@ pub fn decode_full_project_test() {
         project.ProjectId("001"),
         "Project Alpha",
         "The alpha project",
+        color.Color(230, 57, 70),
         True,
         result.unwrap(expected_created, tsutil.timestamp_zero()),
         option.Some(result.unwrap(expected_updated, tsutil.timestamp_zero())),

--- a/webapp/test/test_util.gleam
+++ b/webapp/test/test_util.gleam
@@ -20,6 +20,7 @@ pub fn arbitrary_project() -> project.Project {
     project.ProjectId("P01"),
     "Project Alpha",
     "The Alpha project",
+    color.Color(69, 123, 157),
     False,
     tsutil.timestamp_zero(),
     option.None,


### PR DESCRIPTION
Allow each project to have a color, which is used to derive activity
colors. The first activity inherits the project color, and subsequent
activities progressively darken it by 10%.

The frontend provides a color picker with a curated palette of 16
visually distinct default colors. The backend API accepts color as an
optional field for backwards compatibility — existing projects without
a color fall back to #457b9d.
